### PR TITLE
OCPBUGS-33805: Use exec form entrypoint

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -9,6 +9,6 @@ RUN go build -o _output/kubernetes-kms ./cmd/server/
 FROM registry.access.redhat.com/ubi9:latest
 COPY --from=builder /go/src/github.com/Azure/kubernetes-kms/_output/kubernetes-kms /usr/bin/kubernetes-kms
 
-ENTRYPOINT /usr/bin/kubernetes-kms
+ENTRYPOINT [ "/usr/bin/kubernetes-kms" ]
 
 LABEL io.openshift.release.operator=true


### PR DESCRIPTION
Found the `azure-kms-provider-active` container in the KAS pod to crash when testing https://issues.redhat.com/browse/HOSTEDCP-1234 (secret encryption for HCs on Azure):
```bash
I0516 09:38:22.860917       1 exporter.go:17] "metrics backend" exporter="prometheus"
I0516 09:38:22.861178       1 prometheus_exporter.go:56] "Prometheus metrics server running" address="8095"
I0516 09:38:22.861199       1 main.go:90] "Starting KeyManagementServiceServer service" version="" buildDate=""
E0516 09:38:22.861439       1 main.go:59] "unrecoverable error encountered" err="failed to create key vault client: key vault name, key name and key version are required"
```

This signifies that the following arguments were not passed to the `/usr/bin/kubernetes-kms` binary:
```
- args:
   - --keyvault-name=...
   - --key-name=...
   - --key-version=...
   - --listen-addr=unix:///opt/azurekmsactive.socket
   - --healthz-port=8787
   - --healthz-path=/healthz
   - --config-file-path=/etc/kubernetes/azure.json
   - -v=1
```

This is because the entrypoint statement in shell form:
```bash
ENTRYPOINT /usr/bin/kubernetes-kms
```
prevents any CMD command line arguments from being used. See [docker docs](https://docs.docker.com/reference/dockerfile/#entrypoint). 

This PR changes the entrypoint statement to use the exec form, matching the upstream [Dockerfile](https://github.com/Azure/kubernetes-kms/blob/22004a3828e51eb1bf0ebad3719a390e0d27b7c7/Dockerfile#L26). 
