### PR TITLE
OWNERS: add OCP engineers for KMS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,8 @@ reviewers:
 - muraee
 - bryan-cox
 - jparrill
+- dgrisonnet
+- swghosh
 approvers:
 - sjenning
 - enxebre
@@ -12,4 +14,6 @@ approvers:
 - muraee
 - bryan-cox
 - jparrill
+- dgrisonnet
+- swghosh
 component: hypershift


### PR DESCRIPTION
Add myself and @swghosh to the OWNERS as this repo is used in OCP for KMS support.

This is needed if we want to find a central place to maintain and distribute the plugins for HCP and OCP.
This would also prevent changes that would impact OCP such as https://github.com/openshift/azure-kubernetes-kms/pull/14 to be merged without our awareness.