### PR TITLE
feat(auth): add workload identity authentication support

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -31,6 +31,24 @@ func GetKeyvaultToken(config *config.AzureConfig, aadEndpoint string, proxyMode 
 
 // getCredential returns a token provider for the specified resource.
 func getCredential(config *config.AzureConfig, aadEndpoint string, proxyMode bool) (azcore.TokenCredential, error) {
+	if config.UseFederatedWorkloadIdentityExtension {
+		mlog.Info("using federated workload identity to retrieve access token", "clientID", redactClientCredentials(config.AADClientID))
+		opts := &azidentity.WorkloadIdentityCredentialOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: cloud.Configuration{
+					ActiveDirectoryAuthorityHost: aadEndpoint,
+				},
+			},
+			ClientID:      config.AADClientID,
+			TenantID:      config.TenantID,
+			TokenFilePath: config.AADFederatedTokenFile,
+		}
+		if proxyMode {
+			opts.ClientOptions.Transport = &transporter{}
+		}
+		return azidentity.NewWorkloadIdentityCredential(opts)
+	}
+
 	if config.UseManagedIdentityExtension {
 		mlog.Info("using managed identity to retrieve access token", "clientID", redactClientCredentials(config.UserAssignedIdentityID))
 		opts := &azidentity.ManagedIdentityCredentialOptions{

--- a/pkg/config/azure_config.go
+++ b/pkg/config/azure_config.go
@@ -19,6 +19,13 @@ type AzureConfig struct {
 	AADClientCertPath           string `json:"aadClientCertPath" yaml:"aadClientCertPath"`
 	AADClientCertPassword       string `json:"aadClientCertPassword" yaml:"aadClientCertPassword"`
 	AADMSIDataPlaneIdentityPath string `json:"aadMSIDataPlaneIdentityPath,omitempty" yaml:"aadMSIDataPlaneIdentityPath,omitempty"`
+
+	// UseFederatedWorkloadIdentityExtension enables workload identity authentication
+	// using a federated token projected into the pod. When enabled, AADClientID and
+	// AADFederatedTokenFile must also be set.
+	UseFederatedWorkloadIdentityExtension bool   `json:"useFederatedWorkloadIdentityExtension,omitempty" yaml:"useFederatedWorkloadIdentityExtension,omitempty"`
+	AADClientID                           string `json:"aadClientID,omitempty" yaml:"aadClientID,omitempty"`
+	AADFederatedTokenFile                 string `json:"aadFederatedTokenFile,omitempty" yaml:"aadFederatedTokenFile,omitempty"`
 }
 
 // GetAzureConfig returns configs in the azure.json cloud provider file.


### PR DESCRIPTION
## Summary

- Adds federated workload identity credential support to the Azure KMS provider using `azidentity.NewWorkloadIdentityCredential`
- Adds three new config fields to `AzureConfig`: `UseFederatedWorkloadIdentityExtension`, `AADClientID`, `AADFederatedTokenFile`
- When `UseFederatedWorkloadIdentityExtension` is set in the `azure.json` config, the KMS provider authenticates using the client ID, tenant ID, and a federated token file projected into the pod
- This enables KMS encryption on self-managed Azure HyperShift clusters that use workload identity federation instead of managed identities

## Context

Self-managed Azure HyperShift clusters authenticate with Azure services using workload identity (federated tokens projected into pods via a token-minter sidecar). The current KMS provider does not support this authentication method — it only supports managed identity, client secret, client certificate, and MSI data plane identity.

This change adds workload identity as the highest-priority authentication path in `getCredential()`, consistent with how other Azure components (e.g., cloud-provider-azure) handle workload identity.

## Test plan

- [x] Existing unit tests pass (`go test ./pkg/auth/ ./pkg/config/`)
- [x] Full project builds successfully (`go build ./...`)
- [ ] E2E: Deploy on a self-managed Azure HyperShift cluster with KMS encryption enabled and verify etcd encryption works

🤖 Generated with [Claude Code](https://claude.com/claude-code)