### PR TITLE
CNTRLPLANE-3204: feat: add workload identity support to Azure KMS plugin

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -31,6 +31,22 @@ func GetKeyvaultToken(config *config.AzureConfig, aadEndpoint string, proxyMode 
 
 // getCredential returns a token provider for the specified resource.
 func getCredential(config *config.AzureConfig, aadEndpoint string, proxyMode bool) (azcore.TokenCredential, error) {
+	if config.UseWorkloadIdentityExtension {
+		mlog.Always("using workload identity to retrieve access token")
+		// NOTE: proxy mode is not supported for workload identity. The credential
+		// parameters (ClientID, TenantID, TokenFilePath) are read from the
+		// webhook-injected environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID,
+		// AZURE_FEDERATED_TOKEN_FILE).
+		opts := &azidentity.WorkloadIdentityCredentialOptions{
+			ClientOptions: azcore.ClientOptions{
+				Cloud: cloud.Configuration{
+					ActiveDirectoryAuthorityHost: aadEndpoint,
+				},
+			},
+		}
+		return azidentity.NewWorkloadIdentityCredential(opts)
+	}
+
 	if config.UseManagedIdentityExtension {
 		mlog.Info("using managed identity to retrieve access token", "clientID", redactClientCredentials(config.UserAssignedIdentityID))
 		opts := &azidentity.ManagedIdentityCredentialOptions{

--- a/pkg/config/azure_config.go
+++ b/pkg/config/azure_config.go
@@ -14,8 +14,9 @@ type AzureConfig struct {
 	TenantID                    string `json:"tenantId" yaml:"tenantId"`
 	ClientID                    string `json:"aadClientId" yaml:"aadClientId"`
 	ClientSecret                string `json:"aadClientSecret" yaml:"aadClientSecret"`
-	UseManagedIdentityExtension bool   `json:"useManagedIdentityExtension,omitempty" yaml:"useManagedIdentityExtension,omitempty"`
-	UserAssignedIdentityID      string `json:"userAssignedIdentityID,omitempty" yaml:"userAssignedIdentityID,omitempty"`
+	UseWorkloadIdentityExtension bool   `json:"useWorkloadIdentityExtension,omitempty" yaml:"useWorkloadIdentityExtension,omitempty"`
+	UseManagedIdentityExtension  bool   `json:"useManagedIdentityExtension,omitempty" yaml:"useManagedIdentityExtension,omitempty"`
+	UserAssignedIdentityID       string `json:"userAssignedIdentityID,omitempty" yaml:"userAssignedIdentityID,omitempty"`
 	AADClientCertPath           string `json:"aadClientCertPath" yaml:"aadClientCertPath"`
 	AADClientCertPassword       string `json:"aadClientCertPassword" yaml:"aadClientCertPassword"`
 	AADMSIDataPlaneIdentityPath string `json:"aadMSIDataPlaneIdentityPath,omitempty" yaml:"aadMSIDataPlaneIdentityPath,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `WorkloadIdentityCredential` as a new authentication method for the Azure KMS plugin, enabling workload identity auth to Azure Key Vault
- Triggered by a new `useWorkloadIdentityExtension` boolean in `azure.json`, consistent with the existing `useManagedIdentityExtension` pattern
- Credential parameters (ClientID, TenantID, TokenFilePath) are read from webhook-injected environment variables; cloud/AAD endpoint is set from the `azure.json` `cloud` field

## Details

- `DefaultAzureCredential` was evaluated and rejected because existing auth paths are config-file-driven (`azure.json`), not env-var-driven — see [CNTRLPLANE-3204](https://redhat.atlassian.net/browse/CNTRLPLANE-3204) for full rationale
- Workload identity is checked first in the auth chain (before managed identity) as the more modern/secure method
- Proxy mode is not yet supported for workload identity (noted in code as a known limitation)

## Test plan

- [ ] Verify existing auth paths (managed identity, client secret, client cert, MSI data plane) are unaffected
- [ ] End-to-end testing with self-managed Azure KMS deployment using workload identity
- [ ] `go build ./...` and `go vet ./...` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)