### PR TITLE
CNTRLPLANE-3380: Update OWNERS with HyperShift core team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,24 @@
 reviewers:
-- sjenning
-- enxebre
-- csrwng
-- muraee
 - bryan-cox
-- jparrill
+- clebs
+- csrwng
+- devguyio
 - dgrisonnet
+- enxebre
+- jparrill
+- muraee
+- Nirshal
+- sdminonne
+- sjenning
 - swghosh
 approvers:
-- sjenning
-- enxebre
-- csrwng
-- muraee
 - bryan-cox
-- jparrill
+- csrwng
+- devguyio
 - dgrisonnet
+- enxebre
+- jparrill
+- muraee
+- sjenning
 - swghosh
 component: hypershift


### PR DESCRIPTION
## Summary
- Adds HyperShift core reviewers and approvers to align with the main hypershift repo
- New reviewers: `clebs`, `devguyio`, `Nirshal`, `sdminonne`
- New approvers: `devguyio`
- Alphabetized all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)