### PR TITLE
CNTRLPLANE-3660: Add AGENTS.md, ARCHITECTURE.md, CLAUDE.md, update CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AI Agent Instructions for azure-kubernetes-kms
+
+## What This Repo Is
+
+A Kubernetes KMS (Key Management Service) plugin that enables encryption at rest of etcd data using Azure Key Vault. It communicates with the Kubernetes API server over a gRPC Unix socket. In HyperShift (hosted control planes), the plugin runs as a sidecar container alongside the Kube API server pod. In standalone OpenShift, it is deployed as a static pod on each control plane node.
+
+This is an OpenShift fork of `Azure/kubernetes-kms`. The upstream repo (`azure` remote) is effectively EOL — Microsoft has confirmed it only receives CVE/security patches. This downstream fork carries features not present upstream, including MSI Data Plane Identity (UAMI) support for ARO HCP and Workload Identity support for self-managed Azure.
+
+## Critical Rules
+
+1. **Do not break KMS v1/v2 compatibility.** Both KMS v1 (v1beta1) and v2 (Go package `k8s.io/kms/apis/v2`, protocol version `v2beta1`) APIs are registered on the same gRPC server. Changes must not break either protocol.
+2. **Key version is immutable per encryption.** The plugin does not support transparent key rotation. Creating a new key version without following the multi-pod rotation process will cause decryption failures.
+3. **Do not modify the annotation schema** used during encryption without understanding the decrypt-side validation. v2 strictly validates algorithm and version annotations on decrypt — mismatches cause immediate failure.
+4. **Run `make unit-test` and `make lint` before considering any change complete.**
+
+## Repository Structure
+
+```
+cmd/server/main.go           # Entry point — flag parsing, gRPC server, metrics init
+
+pkg/
+├── plugin/                  # Core KMS logic
+│   ├── keyvault.go          # Azure Key Vault client wrapper (encrypt/decrypt)
+│   ├── server.go            # KMS v1 gRPC server
+│   ├── kms_v2_server.go     # KMS v2 gRPC server
+│   ├── healthz.go           # Health check HTTP server (port 8787)
+│   └── mock_keyvault/       # Test mocks
+├── auth/auth.go             # Azure credential providers (5 methods, see below)
+├── config/azure_config.go   # Parses /etc/kubernetes/azure.json
+├── consts/consts.go         # Proxy mode header constants
+├── metrics/                 # OpenTelemetry + Prometheus instrumentation
+├── utils/                   # gRPC helpers, string sanitization
+└── version/                 # Version info and user agent
+
+scripts/                     # Kind cluster setup for e2e tests
+tests/
+├── client/client_test.go    # Integration tests (require real Azure credentials)
+└── e2e/*.bats               # BATS e2e tests (require Docker for kind clusters)
+
+docs/                        # Manual install, rotation, metrics, testing docs
+developers.md                # LEGACY upstream file — ignore, use this file instead
+Dockerfile.openshift         # OpenShift CI build (used by Prow/ci-operator)
+```
+
+## Key Architecture Concepts
+
+- **Dual API support**: KMS v1 uses RSA-15 encryption; v2 uses RSA-OAEP-256. Both are served on the same Unix socket.
+- **Authentication hierarchy** (checked in order):
+  1. Workload Identity (no proxy support)
+  2. Managed Identity — user-assigned or system-assigned (no proxy support)
+  3. Service Principal with secret (proxy support)
+  4. Client Certificate / PKCS#12 (proxy support)
+  5. MSI Data Plane Identity — UAMI for ARO HCP, downstream-only (no proxy support)
+- **Two health check mechanisms**:
+  - HTTP `/healthz` endpoint: performs a full v1 + v2 encrypt/decrypt cycle (4 Key Vault calls per invocation)
+  - KMS v2 Status RPC: called by the API server approximately every minute, performs an encrypt/decrypt cycle (2 Key Vault calls per invocation)
+- **Unix socket**: Default path is `/opt/azurekms.socket`. The old socket file is explicitly removed before binding. Note: integration tests use `/opt/azurekms.sock` (different extension).
+
+## Build and Test
+
+```bash
+make build          # Binary to _output/kubernetes-kms
+make unit-test      # Unit tests with race detector
+make lint           # golangci-lint
+make integration-test  # Requires real Azure credentials and Key Vault
+make e2e-test       # KMS v1 e2e (requires Docker for kind)
+make e2e-kmsv2-test # KMS v2 e2e (requires Docker for kind)
+```
+
+## What NOT to Do
+
+- Do not add proxy mode support for Workload Identity or MSI Data Plane Identity — this is intentional.
+- Do not assume network access in unit tests. Use the mock Key Vault client in `pkg/plugin/mock_keyvault/`.
+- Do not change the gRPC Unix socket path without updating the encryption configuration docs and deployment manifests.
+- Do not modify the encryption algorithm for a KMS version (v1=RSA-15, v2=RSA-OAEP-256) — existing encrypted data depends on these.
+- Do not remove the explicit `os.Remove(addr)` before socket bind — it prevents stale socket failures on restart.
+- Do not follow instructions in `developers.md` — it is a legacy upstream file with outdated tooling references.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,137 @@
+# Architecture: azure-kubernetes-kms
+
+## Overview
+
+azure-kubernetes-kms is a Kubernetes KMS plugin that enables encryption at rest of etcd data using Azure Key Vault. The plugin exposes a gRPC server over a Unix socket that the Kubernetes API server calls during secret encryption and decryption operations. In HyperShift (hosted control planes), the plugin runs as a sidecar container alongside the Kube API server pod. In standalone OpenShift, it is deployed as a static pod on each control plane node.
+
+This is an OpenShift fork of `Azure/kubernetes-kms`. The upstream repo is effectively EOL (confirmed by Microsoft) and only receives CVE/security patches. This fork carries downstream-only features including MSI Data Plane Identity (UAMI) support for ARO HCP and Workload Identity support for self-managed Azure.
+
+## Component Architecture
+
+```
+Kubernetes API Server
+  │
+  │  gRPC (unix:///opt/azurekms.socket)
+  ↓
+KMS Plugin (static pod per control plane node)
+  ├── gRPC Server
+  │   ├── KMS v1 Server (v1beta1, RSA-15)
+  │   └── KMS v2 Server (k8s.io/kms/apis/v2, protocol v2beta1, RSA-OAEP-256)
+  ├── Key Vault Client (encrypt/decrypt via Azure SDK)
+  ├── Auth Provider (5 methods — see Authentication section)
+  ├── Health Check Server (HTTP :8787, performs real encrypt/decrypt)
+  └── Metrics (OpenTelemetry → Prometheus)
+  │
+  │  HTTPS
+  ↓
+Azure Key Vault
+```
+
+## Data Flow
+
+### Encryption
+
+1. API server sends plaintext to the plugin via gRPC.
+2. Plugin base64-encodes the plaintext (using `base64.RawURLEncoding` — no padding, URL-safe alphabet).
+3. Plugin calls Azure Key Vault's Encrypt API (RSA-15 for v1, RSA-OAEP-256 for v2).
+4. Plugin returns ciphertext plus annotations (algorithm, version, key ID hash) to the API server.
+5. API server stores the encrypted data in etcd with prefix `k8s:enc:kms:v1:azurekmsprovider` or `k8s:enc:kms:v2:azurekmsprovider`.
+
+### Decryption
+
+1. API server sends ciphertext plus annotations to the plugin via gRPC.
+2. Plugin validates annotations — for v2, algorithm and version must match exactly. Key ID hash is validated to detect key mismatches.
+3. Plugin calls Azure Key Vault's Decrypt API.
+4. Plugin base64-decodes the result (using `base64.RawURLEncoding`) and returns plaintext to the API server.
+
+### Health Checks
+
+There are two independent health check mechanisms:
+
+- **HTTP `/healthz` endpoint** (port 8787): Performs a full v1 + v2 encrypt/decrypt cycle against Key Vault (4 API calls per invocation). Called by kubelet liveness probes at the interval configured in the static pod spec.
+- **KMS v2 Status RPC**: Called by the API server approximately every minute. Performs an encrypt/decrypt cycle (2 API calls per invocation, ~120 Key Vault calls/hour per node from this mechanism alone).
+
+Both verify end-to-end functionality, not just connectivity.
+
+## Authentication
+
+The plugin supports five Azure authentication methods, checked in order:
+
+| Method | Config Requirement | Proxy Support |
+|--------|-------------------|---------------|
+| Workload Identity | OIDC token + federated credential | No |
+| Managed Identity (user-assigned) | `userAssignedIdentityID` in azure.json | No |
+| Managed Identity (system-assigned) | `useManagedIdentityExtension: true` | No |
+| Service Principal (secret) | `aadClientId` + `aadClientSecret` | Yes |
+| Client Certificate | `aadClientId` + `aadClientCertPath` (PKCS#12) | Yes |
+| MSI Data Plane Identity | `aadMSIDataPlaneIdentityPath` in azure.json | No |
+
+MSI Data Plane Identity is a downstream-only feature providing UAMI (User Assigned Managed Identity) support for ARO HCP. It uses the `github.com/Azure/msi-dataplane` package.
+
+Only Service Principal and Client Certificate configure a proxy-aware HTTP transport. Proxy mode uses custom headers defined in `pkg/consts/` to route requests through a proxy to Azure AD and Key Vault.
+
+Configuration is read from `/etc/kubernetes/azure.json` (the standard Azure cloud provider config file).
+
+## Deployment
+
+The deployment model depends on the control plane topology:
+
+**HyperShift (hosted control planes):** The plugin runs as a **sidecar container** in the Kube API server pod. The Unix socket is shared between containers via an `emptyDir` volume mount. The control plane operator manages the pod spec and injection of the KMS container.
+
+**Standalone OpenShift:** The plugin is deployed as a **static pod** on each control plane node:
+
+- **Manifest location**: `/etc/kubernetes/manifests/` (managed by kubelet directly)
+- **Network**: `hostNetwork: true` (required for Unix socket access)
+- **Priority**: `system-node-critical`
+- **Security**: Read-only root filesystem, no privilege escalation, all capabilities dropped
+
+The API server references the plugin in its `EncryptionConfiguration` (v1 example shown):
+
+```yaml
+resources:
+  - resources: [secrets]
+    providers:
+      - kms:
+          name: azurekmsprovider
+          endpoint: unix:///opt/azurekms.socket
+          cachesize: 1000
+```
+
+## Key Rotation
+
+The plugin does **not** support transparent key rotation. Rotation requires a multi-step process:
+
+1. Deploy a second KMS plugin instance with the new key on a different socket.
+2. Add both plugins to the encryption configuration (old first).
+3. Restart API servers.
+4. Swap the order (new plugin first for new encryptions).
+5. Restart API servers and re-encrypt all secrets.
+6. Remove the old plugin.
+
+This is documented in `docs/rotation.md`.
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Dual KMS v1/v2 support | Enables zero-downtime migration from v1 to v2. v2 provides stronger encryption (RSA-OAEP-256 vs RSA-15). |
+| Two health check mechanisms | HTTP `/healthz` for kubelet liveness probes; KMS v2 Status RPC for API server health polling. Both do real encrypt/decrypt to guarantee end-to-end functionality. |
+| Unix socket over TCP | Better security — no network exposure. Requires static pod deployment with host access. |
+| Annotation-based metadata | Stores encryption context (algorithm, key version, key ID hash) alongside ciphertext. Enables validation on decrypt and future extensibility. |
+| Static pod (standalone) or sidecar (HyperShift) | In standalone, must run on every control plane node before the API server can start. In HyperShift, runs as a sidecar in the Kube API server pod with a shared Unix socket volume. |
+| MSI Data Plane Identity (downstream) | Enables UAMI for ARO HCP where standard Managed Identity is not available. Uses the `msi-dataplane` package for credential acquisition. |
+
+## Dependencies
+
+- **Azure SDK**: `azure-sdk-for-go/sdk/security/keyvault/azkeys` for Key Vault operations, `azidentity` for authentication
+- **Azure msi-dataplane**: `github.com/Azure/msi-dataplane` for MSI Data Plane Identity (UAMI, downstream-only)
+- **gRPC**: Server framework for KMS protocol
+- **k8s.io/kms**: Kubernetes KMS API definitions (v1beta1, v2)
+- **OpenTelemetry + Prometheus**: Metrics instrumentation and export
+- **mlog**: Structured logging with klog integration
+
+## Testing
+
+- **Unit tests**: In each `pkg/` directory, using mock Key Vault client. Run with `make unit-test`.
+- **Integration tests** (`tests/client/`): Require real Azure credentials and Key Vault. Run with `make integration-test`. Note: uses socket path `/opt/azurekms.sock` (differs from default `/opt/azurekms.socket`).
+- **E2E tests** (`tests/e2e/`): BATS framework, create kind clusters with the plugin deployed via scripts in `scripts/`. Verify actual secret encryption/decryption in etcd. Separate suites for v1 and v2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,59 @@
-# Contributing
+# Contributing to azure-kubernetes-kms
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
+azure-kubernetes-kms is a Kubernetes KMS plugin that enables encryption at rest of etcd data using Azure Key Vault. This is an OpenShift fork of `Azure/kubernetes-kms`.
 
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+The upstream repo is effectively EOL (confirmed by Microsoft) and only receives CVE/security patches. This fork carries downstream-only features including MSI Data Plane Identity (UAMI) support for ARO HCP and Workload Identity support for self-managed Azure. New feature work happens here, not upstream.
+
+The repo contains a legacy `developers.md` from upstream with outdated tooling references (Go 1.9, `dep`). Ignore it — this file and `AGENTS.md` are the current contribution guides.
+
+## Development Workflow
+
+1. Fork the repo and clone your fork.
+2. Create a feature branch from `main`.
+3. Make your changes, add or update tests.
+4. Run verification locally before pushing:
+
+```bash
+make build       # Binary to _output/kubernetes-kms
+make unit-test   # Unit tests with race detector
+make lint        # golangci-lint
+```
+
+5. Push your branch and open a PR against `openshift/azure-kubernetes-kms:main`.
+
+## Pull Request Guidelines
+
+- Keep PRs focused. One logical change per PR.
+- Write clear commit messages. Reference Jira tickets where applicable.
+- Include unit tests for new functionality. Use the mock Key Vault client in `pkg/plugin/mock_keyvault/` — do not assume network access in unit tests.
+- PRs require approval from at least one approver listed in the `OWNERS` file.
+
+## Testing
+
+| Command | What it runs |
+|---------|-------------|
+| `make build` | Compile binary to `_output/kubernetes-kms` |
+| `make unit-test` | Unit tests with race detector |
+| `make lint` | golangci-lint |
+| `make integration-test` | Integration tests (requires real Azure credentials and Key Vault) |
+| `make e2e-test` | KMS v1 e2e tests (requires Docker for kind clusters) |
+| `make e2e-kmsv2-test` | KMS v2 e2e tests (requires Docker for kind clusters) |
+
+E2E tests use the BATS framework and create kind clusters with the plugin deployed. They verify actual secret encryption/decryption in etcd.
+
+## Code Conventions
+
+- Follow standard Go conventions (gofmt, govet).
+- Use existing patterns in the package you are modifying.
+- Both KMS v1 (v1beta1) and v2 (v2beta1) APIs are registered on the same gRPC server. Changes must not break either protocol.
+- Do not modify the encryption algorithm for a KMS version (v1=RSA-15, v2=RSA-OAEP-256) — existing encrypted data depends on these.
+
+## Areas Requiring Extra Care
+
+- **Annotation schema** (`pkg/plugin/`): v2 strictly validates algorithm and version annotations on decrypt. Mismatches cause immediate decryption failure.
+- **Key rotation**: The plugin does not support transparent key rotation. See `docs/rotation.md` for the multi-pod rotation process.
+- **Authentication** (`pkg/auth/`): Supports multiple Azure auth methods in a specific order. Do not add proxy support for Workload Identity — this is an intentional limitation.
+
+## CI
+
+CI runs via OpenShift's CI infrastructure (Prow / ci-operator) using `Dockerfile.openshift` for builds. All `make unit-test` and `make lint` checks must pass for a PR to merge.


### PR DESCRIPTION
## Summary
- Update **CONTRIBUTING.md** with dev workflow, PR guidelines, testing requirements, coding conventions, and areas requiring extra care (replaces upstream Microsoft CLA boilerplate)
- Add **AGENTS.md** with AI agent instructions: dual KMS v1/v2 rules, key immutability constraints, auth hierarchy, build/test commands
- Add **ARCHITECTURE.md** documenting gRPC data flow, authentication methods, static pod deployment model, key rotation process, and design decisions
- Add **CLAUDE.md** as a symlink to AGENTS.md

Part of the Hybrid Platforms Agentic SDLC initiative ([OCPSTRAT-3200](https://redhat.atlassian.net/browse/OCPSTRAT-3200)) — Shift Week contextification effort.

Jira: [CNTRLPLANE-3660](https://redhat.atlassian.net/browse/CNTRLPLANE-3660)

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Review with team for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)