### PR TITLE
OCPSTRAT-3549: Correct Managed HSM endpoints

### DIFF
--- a/pkg/plugin/keyvault.go
+++ b/pkg/plugin/keyvault.go
@@ -293,11 +293,11 @@ func getVaultDNSSuffix(managedHSM bool, cloud string) (string, error) {
 	if managedHSM {
 		switch {
 		case strings.EqualFold(cloud, "AzurePublicCloud"), strings.EqualFold(cloud, "AzureCloud"), cloud == "":
-			return "https://managedhsm.azure.net/", nil
+			return "managedhsm.azure.net", nil
 		case strings.EqualFold(cloud, "AzureChinaCloud"):
 			return "", fmt.Errorf("no HSM endpoint in cloud %s", cloud)
-		case strings.EqualFold(cloud, "AzureGovernmentCloud"):
-			return "", fmt.Errorf("no HSM endpoint in cloud %s", cloud)
+		case strings.EqualFold(cloud, "AzureGovernmentCloud"), strings.EqualFold(cloud, "AzureUSGovernmentCloud"):
+			return "managedhsm.usgovcloudapi.net", nil
 		default:
 			return "", fmt.Errorf("unknown cloud %s", cloud)
 		}

--- a/pkg/plugin/keyvault_test.go
+++ b/pkg/plugin/keyvault_test.go
@@ -188,6 +188,51 @@ func TestGetVaultURL(t *testing.T) {
 	}
 }
 
+func TestGetManagedHSMVaultURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cloud       string
+		expectedURL string
+	}{
+		{
+			name:        "empty cloud defaults to Azure public cloud",
+			expectedURL: "https://testhsm.managedhsm.azure.net/",
+		},
+		{
+			name:        "AzureCloud uses the public Managed HSM endpoint",
+			cloud:       "AzureCloud",
+			expectedURL: "https://testhsm.managedhsm.azure.net/",
+		},
+		{
+			name:        "AzurePublicCloud uses the public Managed HSM endpoint",
+			cloud:       "AzurePublicCloud",
+			expectedURL: "https://testhsm.managedhsm.azure.net/",
+		},
+		{
+			name:        "AzureGovernmentCloud uses the government Managed HSM endpoint",
+			cloud:       "AzureGovernmentCloud",
+			expectedURL: "https://testhsm.managedhsm.usgovcloudapi.net/",
+		},
+		{
+			name:        "AzureUSGovernmentCloud uses the government Managed HSM endpoint",
+			cloud:       "AzureUSGovernmentCloud",
+			expectedURL: "https://testhsm.managedhsm.usgovcloudapi.net/",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			vaultURL, err := getVaultURL("testhsm", true, testCase.cloud)
+			if err != nil {
+				t.Fatalf("expected no error getting Managed HSM URL, got: %v", err)
+			}
+			if vaultURL != testCase.expectedURL {
+				t.Fatalf("expected Managed HSM URL %q, got %q", testCase.expectedURL, vaultURL)
+			}
+		})
+	}
+}
+
 func TestGetKeyIDHash(t *testing.T) {
 	testCases := []struct {
 		name                string


### PR DESCRIPTION
## Summary

Fix Managed HSM URL construction after the Track 2 SDK carry replaced the SDK-provided DNS suffix with a full URL. `getVaultURL` already adds the scheme, vault name, separators, and trailing slash, so `getVaultDNSSuffix` must return only the DNS suffix.

Also enable the supported Azure Government Managed HSM endpoint for both recognized government cloud aliases.

This provider fix is required by openshift/hypershift#9199.

## Testing

- `make build`
- `make unit-test`
- `.tools/golangci-lint run --timeout=5m -v --new-from-rev=upstream/main`

Repository-wide `make lint` still reports six pre-existing issues on `main`; the changed lines report zero issues.