### PR TITLE
OCPSTRAT-3549: support sovereign Managed HSM endpoints

### DIFF
--- a/pkg/plugin/keyvault.go
+++ b/pkg/plugin/keyvault.go
@@ -295,9 +295,13 @@ func getVaultDNSSuffix(managedHSM bool, cloud string) (string, error) {
 		case strings.EqualFold(cloud, "AzurePublicCloud"), strings.EqualFold(cloud, "AzureCloud"), cloud == "":
 			return "managedhsm.azure.net", nil
 		case strings.EqualFold(cloud, "AzureChinaCloud"):
-			return "", fmt.Errorf("no HSM endpoint in cloud %s", cloud)
-		case strings.EqualFold(cloud, "AzureGovernmentCloud"), strings.EqualFold(cloud, "AzureUSGovernmentCloud"):
+			return "managedhsm.azure.cn", nil
+		case strings.EqualFold(cloud, "AzureGovernmentCloud"), strings.EqualFold(cloud, "AzureUSGovernment"), strings.EqualFold(cloud, "AzureUSGovernmentCloud"):
 			return "managedhsm.usgovcloudapi.net", nil
+		case strings.EqualFold(cloud, "AzureGermanCloud"):
+			return "managedhsm.microsoftazure.de", nil
+		case strings.EqualFold(cloud, "AzureBleuCloud"):
+			return "managedhsm.sovcloud-api.fr", nil
 		default:
 			return "", fmt.Errorf("unknown cloud %s", cloud)
 		}
@@ -307,8 +311,12 @@ func getVaultDNSSuffix(managedHSM bool, cloud string) (string, error) {
 		return "vault.azure.net", nil
 	case strings.EqualFold(cloud, "AzureChinaCloud"):
 		return "vault.azure.cn", nil
-	case strings.EqualFold(cloud, "AzureGovernmentCloud"), strings.EqualFold(cloud, "AzureUSGovernmentCloud"):
+	case strings.EqualFold(cloud, "AzureGovernmentCloud"), strings.EqualFold(cloud, "AzureUSGovernment"), strings.EqualFold(cloud, "AzureUSGovernmentCloud"):
 		return "vault.usgovcloudapi.net", nil
+	case strings.EqualFold(cloud, "AzureGermanCloud"):
+		return "vault.microsoftazure.de", nil
+	case strings.EqualFold(cloud, "AzureBleuCloud"):
+		return "vault.sovcloud-api.fr", nil
 	default:
 		return "", fmt.Errorf("unknown cloud %s", cloud)
 	}
@@ -343,8 +351,12 @@ func getAadEndpoint(azureConfig *config.AzureConfig, proxyMode bool, proxyAddres
 		return cloud.AzurePublic.ActiveDirectoryAuthorityHost, nil
 	case strings.EqualFold(azureConfig.Cloud, "AzureChinaCloud"):
 		return cloud.AzureChina.ActiveDirectoryAuthorityHost, nil
-	case strings.EqualFold(azureConfig.Cloud, "AzureGovernmentCloud"):
+	case strings.EqualFold(azureConfig.Cloud, "AzureGovernmentCloud"), strings.EqualFold(azureConfig.Cloud, "AzureUSGovernment"), strings.EqualFold(azureConfig.Cloud, "AzureUSGovernmentCloud"):
 		return cloud.AzureGovernment.ActiveDirectoryAuthorityHost, nil
+	case strings.EqualFold(azureConfig.Cloud, "AzureGermanCloud"):
+		return "https://login.microsoftonline.de/", nil
+	case strings.EqualFold(azureConfig.Cloud, "AzureBleuCloud"):
+		return "https://login.sovcloud-identity.fr/", nil
 	}
 	return "", fmt.Errorf("invalid cloud type %s", azureConfig.Cloud)
 }

--- a/pkg/plugin/keyvault_test.go
+++ b/pkg/plugin/keyvault_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	testEnvs       = []string{"", "AZUREPUBLICCLOUD", "AZURECHINACLOUD", "AZUREUSGOVERNMENTCLOUD"}
-	vaultDNSSuffix = []string{"vault.azure.net", "vault.azure.net", "vault.azure.cn", "vault.usgovcloudapi.net"}
+	testEnvs       = []string{"", "AZUREPUBLICCLOUD", "AZURECHINACLOUD", "AZUREUSGOVERNMENTCLOUD", "AZUREGERMANCLOUD", "AZUREBLEUCLOUD"}
+	vaultDNSSuffix = []string{"vault.azure.net", "vault.azure.net", "vault.azure.cn", "vault.usgovcloudapi.net", "vault.microsoftazure.de", "vault.sovcloud-api.fr"}
 )
 
 func TestNewKeyVaultClientError(t *testing.T) {
@@ -55,8 +55,8 @@ func TestNewKeyVaultClientError(t *testing.T) {
 			keyVersion: "262067a9e8ba401aa8a746c5f1a7e147",
 		},
 		{
-			desc:       "managed hsm not available in the azure environment",
-			config:     &config.AzureConfig{ClientID: "clientid", ClientSecret: "clientsecret", Cloud: "AzureGermanCloud"},
+			desc:       "unknown azure environment",
+			config:     &config.AzureConfig{ClientID: "clientid", ClientSecret: "clientsecret", Cloud: "AzureUnknownCloud"},
 			vaultName:  "testkv",
 			keyName:    "key1",
 			keyVersion: "262067a9e8ba401aa8a746c5f1a7e147",
@@ -214,9 +214,29 @@ func TestGetManagedHSMVaultURL(t *testing.T) {
 			expectedURL: "https://testhsm.managedhsm.usgovcloudapi.net/",
 		},
 		{
+			name:        "AzureUSGovernment uses the government Managed HSM endpoint",
+			cloud:       "AzureUSGovernment",
+			expectedURL: "https://testhsm.managedhsm.usgovcloudapi.net/",
+		},
+		{
 			name:        "AzureUSGovernmentCloud uses the government Managed HSM endpoint",
 			cloud:       "AzureUSGovernmentCloud",
 			expectedURL: "https://testhsm.managedhsm.usgovcloudapi.net/",
+		},
+		{
+			name:        "AzureChinaCloud uses the China Managed HSM endpoint",
+			cloud:       "AzureChinaCloud",
+			expectedURL: "https://testhsm.managedhsm.azure.cn/",
+		},
+		{
+			name:        "AzureGermanCloud uses the German Managed HSM endpoint",
+			cloud:       "AzureGermanCloud",
+			expectedURL: "https://testhsm.managedhsm.microsoftazure.de/",
+		},
+		{
+			name:        "AzureBleuCloud uses the Bleu Managed HSM endpoint",
+			cloud:       "AzureBleuCloud",
+			expectedURL: "https://testhsm.managedhsm.sovcloud-api.fr/",
 		},
 	}
 
@@ -228,6 +248,66 @@ func TestGetManagedHSMVaultURL(t *testing.T) {
 			}
 			if vaultURL != testCase.expectedURL {
 				t.Fatalf("expected Managed HSM URL %q, got %q", testCase.expectedURL, vaultURL)
+			}
+		})
+	}
+}
+
+func TestGetAADEndpoint(t *testing.T) {
+	testCases := []struct {
+		name             string
+		cloud            string
+		expectedEndpoint string
+	}{
+		{
+			name:             "empty cloud defaults to Azure public cloud",
+			expectedEndpoint: "https://login.microsoftonline.com/",
+		},
+		{
+			name:             "AzurePublicCloud uses the public authority",
+			cloud:            "AzurePublicCloud",
+			expectedEndpoint: "https://login.microsoftonline.com/",
+		},
+		{
+			name:             "AzureChinaCloud uses the China authority",
+			cloud:            "AzureChinaCloud",
+			expectedEndpoint: "https://login.chinacloudapi.cn/",
+		},
+		{
+			name:             "AzureGovernmentCloud uses the government authority",
+			cloud:            "AzureGovernmentCloud",
+			expectedEndpoint: "https://login.microsoftonline.us/",
+		},
+		{
+			name:             "AzureUSGovernment uses the government authority",
+			cloud:            "AzureUSGovernment",
+			expectedEndpoint: "https://login.microsoftonline.us/",
+		},
+		{
+			name:             "AzureUSGovernmentCloud uses the government authority",
+			cloud:            "AzureUSGovernmentCloud",
+			expectedEndpoint: "https://login.microsoftonline.us/",
+		},
+		{
+			name:             "AzureGermanCloud uses the German authority",
+			cloud:            "AzureGermanCloud",
+			expectedEndpoint: "https://login.microsoftonline.de/",
+		},
+		{
+			name:             "AzureBleuCloud uses the Bleu authority",
+			cloud:            "AzureBleuCloud",
+			expectedEndpoint: "https://login.sovcloud-identity.fr/",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			endpoint, err := getAadEndpoint(&config.AzureConfig{Cloud: testCase.cloud}, false, "", 0)
+			if err != nil {
+				t.Fatalf("expected no error getting AAD endpoint, got: %v", err)
+			}
+			if endpoint != testCase.expectedEndpoint {
+				t.Fatalf("expected AAD endpoint %q, got %q", testCase.expectedEndpoint, endpoint)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Extend Azure KMS endpoint resolution to support Key Vault and Managed HSM in all Azure clouds supported by HyperShift:

- Azure Public
- Azure US Government, including all existing cloud-name aliases
- Azure China
- Azure German
- Azure Bleu

The plugin now selects both the correct vault/HSM DNS suffix and the matching AAD authority host for each cloud.

## Context

- HyperShift Managed HSM support: https://github.com/openshift/hypershift/pull/9199
- Original Managed HSM endpoint correction: https://github.com/openshift/azure-kubernetes-kms/pull/51
- 4.22 backport: https://github.com/openshift/azure-kubernetes-kms/pull/53

Live HyperShift testing showed that the existing 5.0 plugin supports Public and US Government Managed HSM endpoints but rejects China, German, and Bleu cloud names before constructing a client.

## Validation

- `make unit-test`
- `make lint`

Unit coverage verifies Key Vault and Managed HSM endpoints plus AAD authority selection for every supported cloud and Government alias.